### PR TITLE
Add a pet to an application

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -10,6 +10,9 @@ class ApplicationsController < ApplicationController
 
   def show
     @application = Application.find(params[:id])
+    if params[:name]
+      @pets = Pet.where("name LIKE ?", params[:name])
+    end
   end  
 
 private

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -11,7 +11,7 @@ class ApplicationsController < ApplicationController
   def show
     @application = Application.find(params[:id])
     if params[:name]
-      @pets = Pet.where("name LIKE ?", params[:name])
+      @pets = Pet.search(params[:name])
     end
   end  
 

--- a/app/controllers/pet_applications_controller.rb
+++ b/app/controllers/pet_applications_controller.rb
@@ -1,0 +1,9 @@
+class PetApplicationsController < ApplicationController
+  
+  def create
+    PetApplication.create!(pet_id: params[:pet_id], application_id: params[:application_id])
+
+    redirect_to "/applications/#{params[:application_id]}"
+  end
+
+end

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -9,3 +9,18 @@
     <%= link_to pet.name, "/pets/#{pet.id}" %><br>
   <% end %>
 </div>
+<div class="add_pet_to_application">
+  <h3>Add a Pet to this Application</h3>
+  <%= form_with url: "/applications/#{@application.id}", method: :get, local: true do |form| %>
+    <%= form.label :name, "Search By Pet's Name" %>
+    <%= form.text_field :name %>
+    <%= form.submit "Submit" %>
+  <% end %>
+  <% if @pets != nil %>
+    <div class="list">
+      <% @pets.each do |pet| %>
+        <%= pet.name %><br>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -1,13 +1,15 @@
 <h3>Application Details:</h3>
-<%= "Name: #{@application.name}" %>
-<%= "Address: #{@application.full_address}" %><br>
-<%= "Description: #{@application.description}" %><br>
-<%= "Status: #{@application.status}" %><br>
-<h3>Pets:</h3>
-<div class="list">
-  <% @application.pets.each do |pet| %>
-    <%= link_to pet.name, "/pets/#{pet.id}" %><br>
-  <% end %>
+<div class="application_information">
+  <%= "Name: #{@application.name}" %>
+  <%= "Address: #{@application.full_address}" %><br>
+  <%= "Description: #{@application.description}" %><br>
+  <%= "Status: #{@application.status}" %><br>
+  <h3>Pets:</h3>
+  <div class="list">
+    <% @application.pets.each do |pet| %>
+      <%= link_to pet.name, "/pets/#{pet.id}" %><br>
+    <% end %>
+  </div>
 </div>
 <div class="add_pet_to_application">
   <h3>Add a Pet to this Application</h3>
@@ -19,7 +21,8 @@
   <% if @pets != nil %>
     <div class="list">
       <% @pets.each do |pet| %>
-        <%= pet.name %><br>
+        <%= pet.name %>
+        <%= button_to "Adopt #{pet.name}", "/pet_applications", method: :post, params: { :application_id => @application.id, :pet_id => pet.id } %><br>
       <% end %>
     </div>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,4 +41,6 @@ Rails.application.routes.draw do
   post "/applications", to: "applications#create"
   get "/applications/:id", to: "applications#show"
 
+  post "/pet_applications", to: "pet_applications#create"
+
 end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "applications show page" do
   let!(:shelter1) { Shelter.create!(name:"Paws without Laws", foster_program: false, city: "Denver", rank: 3) }
   let!(:pet_1) { shelter1.pets.create!(name: "Matt", age: 14, breed: "Cat", adoptable: true) }
   let!(:pet_2) { shelter1.pets.create!(name: "Pog", age: 14, breed: "Dog", adoptable: true) }
+  let!(:pet_3) { shelter1.pets.create!(name: "Anetra", age: 3, breed: "Leopard Gecko", adoptable: true) }
   let!(:pet_app_1) { PetApplication.create!(pet_id: pet_1.id, application_id: app_1.id) } 
   let!(:pet_app_2) { PetApplication.create!(pet_id: pet_2.id, application_id: app_1.id) } 
 
@@ -13,14 +14,25 @@ RSpec.describe "applications show page" do
   end
 
   it "displays application information" do
-    expect(page).to have_content("#{app_1.name}")
+    expect(page).to have_content("Name: #{app_1.name}")
     expect(page).to have_content("466 Birch Road Birmingham, Alabama, 35057")
-    expect(page).to have_content("#{app_1.description}")
-    expect(page).to have_content("#{app_1.status}")
+    expect(page).to have_content("Description: #{app_1.description}")
+    expect(page).to have_content("Status: #{app_1.status}")
     expect(page).to have_link(pet_1.name)
     expect(page).to have_link(pet_2.name)
     click_link pet_1.name
     expect(current_path).to eq("/pets/#{pet_1.id}")
+  end
+
+  it "has a section to add pet a pet to the application" do
+    within(".add_pet_to_application") do
+      expect(page).to have_content("Add a Pet to this Application")
+      expect(page).to have_field(:name)
+      fill_in "Search By Pet's Name", with: pet_3.name
+      click_button "Submit"
+      expect(current_path).to eq("/applications/#{app_1.id}")
+      expect(page).to have_content(pet_3.name)
+    end
   end
 
 

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -24,13 +24,27 @@ RSpec.describe "applications show page" do
     expect(current_path).to eq("/pets/#{pet_1.id}")
   end
 
-  it "has a section to add pet a pet to the application" do
+  it "has a field for searching by pet name" do
     within(".add_pet_to_application") do
       expect(page).to have_content("Add a Pet to this Application")
       expect(page).to have_field(:name)
       fill_in "Search By Pet's Name", with: pet_3.name
       click_button "Submit"
       expect(current_path).to eq("/applications/#{app_1.id}")
+      expect(page).to have_content(pet_3.name)
+    end
+  end
+
+  it "has a button to adopt pet; when clicked pet is added to the application" do
+    within(".add_pet_to_application") do
+      fill_in "Search By Pet's Name", with: pet_3.name
+      click_button "Submit"
+      expect(page).to have_content("Adopt #{pet_3.name}")
+      click_button "Adopt #{pet_3.name}"
+      expect(current_path).to eq("/applications/#{app_1.id}")
+      expect(page).to_not have_content(pet_3.name)
+    end
+    within(".application_information") do
       expect(page).to have_content(pet_3.name)
     end
   end


### PR DESCRIPTION
Creates functionality for selecting a searched pet's name and adding it to an application via an "Adopt" button within the application form. Clicking this button adds the chosen pet to the application - resulting in the creation of a pet application. The `pet_applications_controller#create` also created.

User Story #5 
As a visitor
When I visit an application's show page
And I search for a Pet by name
And I see the names Pets that match my search
Then next to each Pet's name I see a button to "Adopt this Pet"
When I click one of these buttons
Then I am taken back to the application show page
And I see the Pet I want to adopt listed on this application

## Checklist before requesting a review
- [ X ] I have ensured rspec suite is passing in its entirety 

