### PR TITLE
user stories 8 & 9

### DIFF
--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "applications show page" do
   let!(:pet_1) { shelter1.pets.create!(name: "Matt", age: 14, breed: "Cat", adoptable: true) }
   let!(:pet_2) { shelter1.pets.create!(name: "Pog", age: 14, breed: "Dog", adoptable: true) }
   let!(:pet_3) { shelter1.pets.create!(name: "Anetra", age: 3, breed: "Leopard Gecko", adoptable: true) }
+  let!(:pet_4) { shelter1.pets.create!(name: "Alaska", age: 6, breed: "Cat", adoptable: true) }
   let!(:pet_app_1) { PetApplication.create!(pet_id: pet_1.id, application_id: app_1.id) } 
   let!(:pet_app_2) { PetApplication.create!(pet_id: pet_2.id, application_id: app_1.id) } 
   
@@ -113,5 +114,21 @@ RSpec.describe "applications show page" do
         expect(page).to_not have_content("Add a Pet to this Application")
       end
     end
+  end
+
+  it "returns partial matches in pet name search" do
+    fill_in "Search By Pet's Name", with: "a"
+    click_button "Search"
+    expect(page).to have_content(pet_3.name)
+    expect(page).to have_content(pet_4.name)
+  end
+
+  it "is not case sensitive" do
+    fill_in "Search By Pet's Name", with: "ANETRA"
+    click_button "Search"
+    expect(page).to have_content(pet_3.name)
+    fill_in "Search By Pet's Name", with: "anetra"
+    click_button "Search"
+    expect(page).to have_content(pet_3.name)
   end
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -4,6 +4,16 @@ RSpec.describe Application, type: :model do
   describe "relationships" do
     it { should have_many :pet_applications }
     it { should have_many(:pets).through(:pet_applications) }
+  end
 
+  describe "instance methods" do
+    
+    let!(:app_1) { Application.create!(name: "Bob", street_address: "466 Birch Road", city: "Birmingham", state: "Alabama", zip_code: "35057", description: "description", status: "In Progress" ) }
+    
+    describe "#full_address" do
+      it "formats full addresses" do
+        expect(app_1.full_address).to eq("466 Birch Road Birmingham, Alabama, 35057")
+      end
+    end
   end
 end


### PR DESCRIPTION
Added testing for partial matches of pet name search, as well as testing for case insensitive pet name searches. Added instance method testing for `#full_address` method in application model.

user story #8:
`As a visitor
When I visit an application show page
And I search for Pets by name
Then I see any pet whose name PARTIALLY matches my search
For example, if I search for "fluff", my search would match pets with names "fluffy", "fluff", and "mr. fluff"`

user story #9:
`As a visitor
When I visit an application show page
And I search for Pets by name
Then I see any pet whose name PARTIALLY matches my search
For example, if I search for "fluff", my search would match pets with names "fluffy", "fluff", and "mr. fluff"`

## Checklist before requesting a review
- [ x ] I have ensured rspec suite is passing in its entirety 

