### PR TITLE
Approving a pet for adoption

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -39,6 +39,22 @@ body {
   margin-left: 20px;
 }
 
+.list form, #approved-pet{
+  display: inline;
+}
+
+#approved-pet {
+  font-style: italic;
+  color:green;
+  font-weight: bold;
+}
+
+#rejected-pet {
+  font-style: italic;
+  color:red;
+  font-weight: bold;
+}
+
 .application_information h3, h4 {
   padding-top: 10px;
   padding-left: 10px;

--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -1,0 +1,15 @@
+class Admin::ApplicationsController < ApplicationController
+  def show
+    @application = Application.find(params[:id])
+    @pets = @application.pets
+  end
+
+  def update
+    application = Application.find(params[:application_id])
+    pet_application = application.find_pet_app(params[:pet_id])
+    pet_application.update(status: params[:status])
+    pet_application.save
+
+    redirect_to "/admin/applications/#{application.id}"
+  end
+end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -15,7 +15,7 @@ class Application < ApplicationRecord
   end
 
   def find_pet_app(id)
-    self.pet_applications.where("pet_id = #{id}").first
+    pet_applications.where("pet_id = #{id}").first
   end
 end
 

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -14,5 +14,8 @@ class Application < ApplicationRecord
     street_address + " " + city + ", " + state + ", " + zip_code
   end
 
+  def find_pet_app(id)
+    self.pet_applications.where("pet_id = #{id}").first
+  end
 end
 

--- a/app/models/pet_application.rb
+++ b/app/models/pet_application.rb
@@ -1,4 +1,8 @@
 class PetApplication < ApplicationRecord
+  validates :pet_id, presence: true
+  validates :application_id, presence: true
+  validates :status, inclusion: { in: ["Pending", "Accepted", "Rejected"] }
+  
   belongs_to :pet
   belongs_to :application
 end

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -1,0 +1,29 @@
+<div class="application_information">
+  <h3>Application Details:</h3>
+  <p><%= "Name: #{@application.name}" %></p>
+  <p><%= "Address: #{@application.full_address}" %></p>
+  <p><%= "Description: #{@application.description}" %></p>
+  <p><%= "Status: #{@application.status}" %></p>
+  
+  <h4>Pet(s) to adopt:</h4>
+  <div class="list">
+    <% "Pet(s) not yet selected. " if @application.pets.empty? %>
+    
+    <% if @application.status == "Pending" %>
+      <% @application.pets.each do |pet| %>
+        <div>
+          <%= link_to pet.name, "/pets/#{pet.id}" %>
+          <% if @application.find_pet_app(pet.id).status == "Pending" %>
+            <%= button_to "Approve", "/admin/applications/#{pet.id}", method: :patch, id: "approve-#{pet.id}", params: { application_id: @application.id, pet_id: pet.id, status: "Accepted" } %>
+          <% elsif @application.find_pet_app(pet.id).status == "Accepted" %>
+            <p id="approved-pet">Approved!</p>
+          <% end %>
+        </div><br>
+      <% end %>
+    <% else %>
+      <% @application.pets.each do |pet| %>
+        <%= link_to pet.name, "/pets/#{pet.id}" %><br>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,5 +47,8 @@ Rails.application.routes.draw do
   # get '/admin/shelters', to: 'admin_shelters#index' this is handrolling but i wanted to learn how to use namespacing and resources
   namespace :admin do 
     resources :shelters, only: [:index]
+    resources :applications, only: [:show, :update]
   end
+
+  patch "/admin/applications/:id", to: "admin/applications#update"
 end

--- a/db/migrate/20230717155318_add_status_to_pet_applications.rb
+++ b/db/migrate/20230717155318_add_status_to_pet_applications.rb
@@ -1,0 +1,5 @@
+class AddStatusToPetApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :pet_applications, :status, :string, :default => "Pending"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_14_230204) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_17_155318) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,6 +31,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_14_230204) do
     t.bigint "application_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status", default: "Pending"
     t.index ["application_id"], name: "index_pet_applications_on_application_id"
     t.index ["pet_id"], name: "index_pet_applications_on_pet_id"
   end

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe "Admin application show page ('/admin/applications/:id')", type: :feature do
+  let!(:app_1) { Application.create!(name: "Bob", street_address: "466 Birch Road", city: "Birmingham", state: "Alabama", zip_code: "35057", description: "description", status: "Pending" ) }
+  let!(:app_2) { Application.create!(name: "Tina Belcher", street_address: "466 Albion Street", city: "New York", state: "New York", zip_code: "10001", description: "We have lots of fun", status: "In Progress" ) }
+  let!(:shelter1) { Shelter.create!(name:"Paws without Laws", foster_program: false, city: "Denver", rank: 3) }
+  let!(:pet_1) { shelter1.pets.create!(name: "Matt", age: 14, breed: "Cat", adoptable: true) }
+  let!(:pet_2) { shelter1.pets.create!(name: "Pog", age: 14, breed: "Dog", adoptable: true) }
+  let!(:pet_3) { shelter1.pets.create!(name: "Anetra", age: 3, breed: "Leopard Gecko", adoptable: true) }
+  let!(:pet_4) { shelter1.pets.create!(name: "Alaska", age: 6, breed: "Cat", adoptable: true) }
+  let!(:pet_app_1) { PetApplication.create!(pet_id: pet_1.id, application_id: app_1.id) } 
+  let!(:pet_app_2) { PetApplication.create!(pet_id: pet_2.id, application_id: app_1.id) } 
+  
+  before :each do
+    visit "/admin/applications/#{app_1.id}"
+  end
+
+  context "Approving a pet" do
+    it 'has a a button to approve the application for each pet' do
+      expect(page).to have_button("Approve")
+      expect(page).to have_css("#approve-#{pet_1.id}")
+      expect(page).to have_css("#approve-#{pet_2.id}")
+
+      expect(page).to_not have_content(pet_3.name)
+      expect(page).to_not have_content(pet_4.name)
+    end
+
+    it "redirects to the admin show page, after being clicked" do
+      find("#approve-#{pet_1.id}").click
+
+      expect(current_path).to eq("/admin/applications/#{app_1.id}")
+    end
+
+    it "shows no approval button after being clicked" do
+      find("#approve-#{pet_1.id}").click
+
+      expect(page).to_not have_css("#approve-#{pet_1.id}")
+      expect(page).to have_css("#approve-#{pet_2.id}")
+    end
+
+    it "shows a message that the pet has been approved" do
+      find("#approve-#{pet_1.id}").click
+
+      expect(page).to have_content("Approved!")
+      expect(pet_1.name).to appear_before("Approved!")
+      expect("Approved!").to appear_before(pet_2.name)
+    end
+  end
+end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe Application, type: :model do
   end
 
 describe "validations" do
-  let!(:app_1) { Application.create!(name: "Bob", street_address: "466 Birch Road", city: "Birmingham", state: "Alabama", zip_code: "35057", description: "description", status: "In Progress" ) }
-
   it {should validate_presence_of :name}
   it {should validate_presence_of :street_address}
   it {should validate_presence_of :city}
@@ -20,12 +18,20 @@ end
 
   describe "instance methods" do
     
-    let!(:app_1) { Application.create!(name: "Bob", street_address: "466 Birch Road", city: "Birmingham", state: "Alabama", zip_code: "35057", description: "description", status: "In Progress" ) }
+    let!(:app_1) { Application.create!(name: "Bob", street_address: "466 Birch Road", city: "Birmingham", state: "Alabama", zip_code: "35057", description: "description", status: "Pending" ) }
+    let!(:shelter1) { Shelter.create!(name:"Paws without Laws", foster_program: false, city: "Denver", rank: 3) }
+    let!(:pet_1) { shelter1.pets.create!(name: "Matt", age: 14, breed: "Cat", adoptable: true) }
+    let!(:pet_app_1) { PetApplication.create!(pet_id: pet_1.id, application_id: app_1.id) } 
+  
     
     describe "#full_address" do
       it "formats full addresses" do
         expect(app_1.full_address).to eq("466 Birch Road Birmingham, Alabama, 35057")
       end
+    end
+
+    it 'finds a relevant pet_application' do
+      expect(app_1.find_pet_app(pet_1.id)).to eq(pet_app_1)
     end
   end
 end

--- a/spec/models/pet_application_spec.rb
+++ b/spec/models/pet_application_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe PetApplication, type: :model do
   end
 
   describe "validations" do
-  it {should validate_presence_of :pet_id}
-  it {should validate_presence_of :application_id}
-  it {should validate_inclusion_of(:status).in_array(["Pending", "Accepted", "Rejected"])}
+    it {should validate_presence_of :pet_id}
+    it {should validate_presence_of :application_id}
+    it {should validate_inclusion_of(:status).in_array(["Pending", "Accepted", "Rejected"])}
   end
 end

--- a/spec/models/pet_application_spec.rb
+++ b/spec/models/pet_application_spec.rb
@@ -5,4 +5,10 @@ RSpec.describe PetApplication, type: :model do
     it { should belong_to :pet }
     it { should belong_to :application }
   end
+
+  describe "validations" do
+  it {should validate_presence_of :pet_id}
+  it {should validate_presence_of :application_id}
+  it {should validate_inclusion_of(:status).in_array(["Pending", "Accepted", "Rejected"])}
+  end
 end


### PR DESCRIPTION
## Describe your changes
- Creates a `status` column to the `pet_applications` table, and model validations + tests
- Adds tests for Admin applications show page, and Approve Pet Application functionality
- Updates admin routes/ controller methods for Applications show page
- Creates/updates relevant views
## User story
```
12. Approving a Pet for Adoption
When I visit an admin application show page ('/admin/applications/:id')
For every pet that the application is for, I see a button to approve the application for that specific pet
When I click that button
Then I'm taken back to the admin application show page
And next to the pet that I approved, I do not see a button to approve this pet
And instead I see an indicator next to the pet that they have been approved
```
## Checklist before requesting a review
- [ x ] I have ensured rspec suite is passing in its entirety 

