### PR TITLE
Rejecting a pet for adoption

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -39,7 +39,7 @@ body {
   margin-left: 20px;
 }
 
-.list form, #approved-pet{
+.list form, #approved-pet, #rejected-pet {
   display: inline;
 }
 

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -15,8 +15,11 @@
           <%= link_to pet.name, "/pets/#{pet.id}" %>
           <% if @application.find_pet_app(pet.id).status == "Pending" %>
             <%= button_to "Approve", "/admin/applications/#{pet.id}", method: :patch, id: "approve-#{pet.id}", params: { application_id: @application.id, pet_id: pet.id, status: "Accepted" } %>
+            <%= button_to "Reject", "/admin/applications/#{pet.id}", method: :patch, id: "reject-#{pet.id}", params: { application_id: @application.id, pet_id: pet.id, status: "Rejected" } %>
           <% elsif @application.find_pet_app(pet.id).status == "Accepted" %>
             <p id="approved-pet">Approved!</p>
+          <% else #if status "Rejected" %>
+            <p id="rejected-pet">Rejected</p>
           <% end %>
         </div><br>
       <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,8 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+PetApplication.destroy_all
+Application.destroy_all
 Pet.destroy_all
 Shelter.destroy_all
 Veterinarian.destroy_all

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -46,4 +46,36 @@ RSpec.describe "Admin application show page ('/admin/applications/:id')", type: 
       expect("Approved!").to appear_before(pet_2.name)
     end
   end
+
+  context "Rejecting a pet" do
+    it 'has a a button to Reject the application for each pet' do
+      expect(page).to have_button("Reject")
+      expect(page).to have_css("#reject-#{pet_1.id}")
+      expect(page).to have_css("#reject-#{pet_2.id}")
+
+      expect(page).to_not have_content(pet_3.name)
+      expect(page).to_not have_content(pet_4.name)
+    end
+
+    it "redirects to the admin show page, after being clicked" do
+      find("#reject-#{pet_1.id}").click
+
+      expect(current_path).to eq("/admin/applications/#{app_1.id}")
+    end
+
+    it "shows no approval button after being clicked" do
+      find("#reject-#{pet_1.id}").click
+
+      expect(page).to_not have_css("#reject-#{pet_1.id}")
+      expect(page).to have_css("#reject-#{pet_2.id}")
+    end
+
+    it "shows a message that the pet has been Rejectd" do
+      find("#reject-#{pet_1.id}").click
+
+      expect(page).to have_content("Rejected")
+      expect(pet_1.name).to appear_before("Rejected")
+      expect("Rejected").to appear_before(pet_2.name)
+    end
+  end
 end


### PR DESCRIPTION
## Describe your changes
- Fixes Seed file destroy_all methods causing a production issue with Pet Applications
- Adds test and views for Admin - reject pet application button
## User story
```
13. Rejecting a Pet for Adoption
When I visit an admin application show page ('/admin/applications/:id')
For every pet that the application is for, I see a button to reject the application for that specific pet
When I click that button
Then I'm taken back to the admin application show page
And next to the pet that I rejected, I do not see a button to approve or reject this pet
And instead I see an indicator next to the pet that they have been rejected
```
## Checklist before requesting a review
- [ x ] I have ensured rspec suite is passing in its entirety 

